### PR TITLE
Some minor things: SyntaxTypo + better(?) scenario

### DIFF
--- a/bucket.rb
+++ b/bucket.rb
@@ -80,7 +80,10 @@ def test_4_3_2
   by = Bucket.new(3)
   steps = measure(bx, by, 2)
 
-  assert_equal(steps.size, 8)
+  # How about - (0,0)->(0,3)->(3,0)->(3,3)->(4,2)
+  # ['by.fill', 'by.transfer(bx)','by.fill','by.transfer(bx)'] 
+  # Is this not allowed ??? 
+  assert_equal(steps.size, 4)
 
   steps.each do |step|
     puts "Invalid step -- #{step}" && raise unless step_valid?(step)
@@ -90,6 +93,6 @@ def test_4_3_2
     assert_valid_bucket(by)
   end
 
-  assert_equal(bx.current == 2 || by.current == 2)
+  assert(bx.current == 2 || by.current == 2)
 end
 


### PR DESCRIPTION
Hello,

just followed your code task and I think there is somehing screwed up (I might be wrong - if so, please explain why ✋ ).

1. Obvious `assert_equal` is defined to take two parameters, so there were probably intended here usage of `assert`. Just a typo.

2. I believe in counting of min numer of steps this might be done better (for tuple [4,3,2]) - steps in comments.

Cheers,
Piotr